### PR TITLE
FIX: content url mismatch & icons listing

### DIFF
--- a/content.js
+++ b/content.js
@@ -138,7 +138,7 @@ class ChatGPTThreadViewer {
   
   // Initialize the viewer when page loads
   function initChatGPTThreadViewer() {
-    if (window.location.hostname === 'chat.openai.com') {
+    if (window.location.hostname === 'chatgpt.com') {
       new ChatGPTThreadViewer();
     }
   }

--- a/manifest.json
+++ b/manifest.json
@@ -8,25 +8,24 @@
       "activeTab",
       "tabs"
     ],
-    "host_permissions": [
-      "https://chat.openai.com/*"
-    ],
-    "action": {
-      "default_popup": "popup.html",
-      "default_icon": {
+    "host_permissions": ["https://chatgpt.com/*"],
+    "icons": {
         "16": "icon16.png",
         "48": "icon48.png",
         "128": "icon128.png"
+    },
+    "action": {
+      "default_popup": "popup.html",
+      "default_icon": {
+        "48": "icon48.png"
       }
     },
     "background": {
       "service_worker": "background.js"
     },
     "content_scripts": [{
-      "matches": ["https://chat.openai.com/*"],
+      "matches": ["https://chatgpt.com/*"],
       "js": ["content.js"],
       "css": ["styles.css"]
     }]
-  }
-  
-    
+}


### PR DESCRIPTION
@irohit-mishra: PR addresses the following:

1. Simple fix for extension UI not loading. This is due to mismatch between site host name "chatgpt.com" vs "chat.openai.com". The domain was changed a couple of months ago.

![image](https://github.com/user-attachments/assets/22db5476-6b7f-4ebd-ac27-c6eac0343e0b)


3. In the manifest.json file, "icons" should be its own first-level object. When nested inside of "action", the extension icon is not displayed in the extensions page (brave://extensions, chrome://extensions, etc), or stores (if uploaded later on).

![image](https://github.com/user-attachments/assets/b5d1dd32-ef74-4804-b822-48be410bd2e6)
